### PR TITLE
Similar_word仅保留真正同义词，过滤相关词和独立词

### DIFF
--- a/nlpcda/tools/Similar_word.py
+++ b/nlpcda/tools/Similar_word.py
@@ -18,6 +18,9 @@ class Similarword(Basetool):
         combine_dict = {}
         for line in open(self.base_file, "r", encoding='utf-8'):
             seperate_word = line.strip().split(" ")
+            # 仅保留真正近义词，过滤相关词和独立词
+            if not seperate_word[0].endswith("="):
+                continue
             num = len(seperate_word)
             for i in range(1, num):
                 wi = seperate_word[i]


### PR DESCRIPTION
发现在使用`Similarword`的时候，有时会出现把“动物”替换成“植物”这样的情况（都接近反义词了），可能会损害阅读理解等需要事实正确的任务的表现。

出现这个问题的原因是因为同义词词林里不光包括同义词，也有“相关词”，而原始实现中没有区分二者，导致相关词也被用作替换。关于同义词词林的说明可见 [这个说明](https://github.com/yaleimeng/Final_word_Similarity/blob/master/cilin/%e5%90%8c%e4%b9%89%e8%af%8d%e8%af%8d%e6%9e%97%e6%89%a9%e5%b1%95%e7%89%88%e8%af%b4%e6%98%8e.pdf)

![image](https://user-images.githubusercontent.com/32953014/124701328-f35f7900-df20-11eb-988c-2126f644fbf3.png)

比如出问题的一行就是`Ba02A20# 动物 植物 微生物`

我做了一个简单的修复，希望能merge进去吧