### PR TITLE
Replace set_rtype to new wraps api in bert4keras

### DIFF
--- a/nlpcda/tools/simbert/generator.py
+++ b/nlpcda/tools/simbert/generator.py
@@ -43,7 +43,7 @@ class SynonymsGenerator(AutoRegressiveDecoder):
         super().__init__(start_id=None, end_id=self.tokenizer._token_end_id,
                          maxlen=self.max_len)
 
-    @AutoRegressiveDecoder.set_rtype('probas')
+    @AutoRegressiveDecoder.wraps('probas')
     def predict(self, inputs, output_ids, states):
         token_ids, segment_ids = inputs
         token_ids = np.concatenate([token_ids, output_ids], 1)


### PR DESCRIPTION
bert4keras replaced set_rtype in AutoRegressiveDecoder with wraps. This will fix the error with bert4keras 0.11.3.